### PR TITLE
Fixed indentation issue, and added PHP functions and hotkey support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To install, place the ```annotate``` folder inside the ```brackets/src/extension
 Usage
 =====
 Open a project in Brackets, place your cursor before a function definition, and select ```Annotate``` form the ```Edit``` menu.
+Alternatively, use the keyboard shortcut `CTRL` + `Shift` + `D` on Windows, or `⌘`. + `Shift` + `D` on Mac.
 
 This will create a JSDoc like annotation according to the function signature.  It will add ```@private``` if the function starts with an underscore. It will create a ```@param``` for each parameter.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install, place the ```annotate``` folder inside the ```brackets/src/extension
 Usage
 =====
 Open a project in Brackets, place your cursor before a function definition, and select ```Annotate``` form the ```Edit``` menu.
-Alternatively, use the keyboard shortcut `CTRL` + `Shift` + `D` on Windows, or `⌘`. + `Shift` + `D` on Mac.
+Alternatively, use the keyboard shortcut `CTRL`+`Shift`+`D` on Windows, or `⌘`+`Shift`+`D` on Mac.
 
 This will create a JSDoc like annotation according to the function signature.  It will add ```@private``` if the function starts with an underscore. It will create a ```@param``` for each parameter.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ To install, place the ```annotate``` folder inside the ```brackets/src/extension
 
 Usage
 =====
-Open a project in Brackets, place your cursor before a function definition, and select ```Annotate``` form the ```Edit``` menu.
+Open a project in Brackets, place your cursor before, or on the line of a function definition, and select ```Annotate``` form the ```Edit``` menu.
+
 Alternatively, use the keyboard shortcut `CTRL`+`Shift`+`D` on Windows, or `⌘`+`Shift`+`D` on Mac.
 
 This will create a JSDoc like annotation according to the function signature.  It will add ```@private``` if the function starts with an underscore. It will create a ```@param``` for each parameter.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A brackets extension to generate JSDoc annotations for your functions.
 
 To install, place the ```annotate``` folder inside the ```brackets/src/extensions/user``` folder.
 
-**Compatible with Brackets Sprint10**
+**Compatible with Brackets Sprint10 and higher**
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -17,6 +17,4 @@ This will create a JSDoc like annotation according to the function signature.  I
 Known issues
 =====
 
-Annotations are not correctly indented.
-
 No ```@return``` is generated since the extension only looks at the function signature to generate the annotation, not its body.

--- a/main.js
+++ b/main.js
@@ -30,9 +30,10 @@ define(function (require, exports, module) {
     'use strict';
 
 
-    var CommandManager = brackets.getModule("command/CommandManager"),
-        EditorManager  = brackets.getModule("editor/EditorManager"),
-        Menus          = brackets.getModule("command/Menus");
+    var CommandManager      = brackets.getModule("command/CommandManager"),
+        EditorManager       = brackets.getModule("editor/EditorManager"),
+        KeyBindingManager   = brackets.getModule("command/KeyBindingManager"),
+        Menus               = brackets.getModule("command/Menus");
 
 
     var EMPTY_MSG   = "No function found";
@@ -44,7 +45,7 @@ define(function (require, exports, module) {
     function insert(input) {            
         
         var editor = EditorManager.getCurrentFullEditor();
-        var pos = editor.getCursorPos();
+        var pos    = editor.getCursorPos();
         pos.ch = 0;       
  
         editor._codeMirror.replaceRange(input, pos);
@@ -61,7 +62,7 @@ define(function (require, exports, module) {
     function getPrefix(input, match) {
         
         var indexOf = input.indexOf(match),
-            prefix = "";
+            prefix  = "";
         if (indexOf != -1) {
             prefix = input.substr(0, indexOf);
         }
@@ -73,7 +74,7 @@ define(function (require, exports, module) {
     function getTarget() {
         
         var editor = EditorManager.getCurrentFullEditor();
-        var pos = editor.getCursorPos();
+        var pos    = editor.getCursorPos();
         pos.ch = 0;       
  
         // Take the text of the document, starting with the current cursor line
@@ -183,6 +184,7 @@ define(function (require, exports, module) {
 
 
     CommandManager.register(MENU_NAME, COMMAND_ID, annotate);
+    KeyBindingManager.addBinding(COMMAND_ID, "Ctrl-Shift-D");
 
     var menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
     menu.addMenuDivider();

--- a/main.js
+++ b/main.js
@@ -45,18 +45,37 @@ define(function (require, exports, module) {
         
         var editor = EditorManager.getCurrentFullEditor();
         var pos = editor.getCursorPos();
-        
+        pos.ch = 0;       
+ 
         editor._codeMirror.replaceRange(input, pos);
 
-        EditorManager.focusEditor();        
+        EditorManager.focusEditor();
+        
     }
-
+    
+    /**
+     * get the whitespace characters from line start to beginning of function def
+     * @param string input lines from start of the function definition
+     * @param string match function definition start
+     */
+    function getPrefix(input, match) {
+        
+        var indexOf = input.indexOf(match),
+            prefix = "";
+        if (indexOf != -1) {
+            prefix = input.substr(0, indexOf);
+        }
+        
+        return prefix;
+        
+    }
     
     function getTarget() {
         
         var editor = EditorManager.getCurrentFullEditor();
         var pos = editor.getCursorPos();
-        
+        pos.ch = 0;       
+ 
         // Take the text of the document, starting with the current cursor line
         var txtFrom = editor._codeMirror.getRange(pos, {line: editor._codeMirror.lineCount() });
         
@@ -72,13 +91,36 @@ define(function (require, exports, module) {
         if (results[0] === "function") {
             return {
                 name: results[1],
-                params: results.slice(2)
+                params: results.slice(2),
+                prefix: getPrefix(txtFrom, results[0])
             };
         } 
-        else if (results[0] === "var" && results[2] === "function") { 
+        else if (results[0] === "private" && results[1] === "function") { 
             return {
                 name: results[1],
-                params: results.slice(3)
+                params: results.slice(3),
+                prefix: getPrefix(txtFrom, results[0])
+            };            
+        }
+        else if (results[0] === "public" && results[1] === "function") { 
+            return {
+                name: results[1],
+                params: results.slice(3),
+                prefix: getPrefix(txtFrom, results[0])
+            };            
+        }
+        else if (results[0] === "static" && results[1] === "function") { 
+            return {
+                name: results[1],
+                params: results.slice(3),
+                prefix: getPrefix(txtFrom, results[0])
+            };            
+        }
+        else if (results[0] === "var" && results[1] === "function") { 
+            return {
+                name: results[1],
+                params: results.slice(3),
+                prefix: getPrefix(txtFrom, results[0])
             };            
         }
         else {
@@ -88,32 +130,39 @@ define(function (require, exports, module) {
     }
     
     
-    function generateComment(fname, params) {
+    /**
+     * Generate comment block
+     * @param string fname function name
+     * @param string params function parameters
+     * @param string prefix whitespace prefix for comment block lines
+     */
+    function generateComment(fname, params, prefix) {
         
-        var output = "/**\n";
+        var output = [];
+        output.push("/**");
                 
         // Assume function is private if it starts with an underscore
         if (fname.charAt(0) === "_") {
-            output += " * @private\n";
+            output.push(" * @private");
         }
         
         // Add description
-        output += " * Description\n";
+        output.push(" * Description");
         
         // Add parameters
         if (params.length > 0) {
             var i;
             for (i = 0; i < params.length; i++) {
                 var param = params[i];
-                output += " * @param {type} " + param + " Description\n";
+                output.push(" * @param {type} " + param + " Description");
             }
         }
         
         // TODO use if 'return' is found in the function body?
         //output += " * @return {type} ???\n";
-        output += " */\n";
+        output.push(" */");
         
-        return output;
+        return prefix + output.join("\n" + prefix) + "\n";
     }
 
     
@@ -127,7 +176,7 @@ define(function (require, exports, module) {
             return;
         }
         
-        var comment = generateComment(target.name, target.params);
+        var comment = generateComment(target.name, target.params, target.prefix);
         
         insert(comment);
     }


### PR DESCRIPTION
Fixed indentation issue #4 and previously the cursor had to be placed before the function definition for the extension to work, now it does not.

The getTarget() function now checks from the start of the line, and generateComment() now prefixes the comment block with the same whitespace spaces or tabs indentation as the function def line used.

CMD/Ctrl + Shift + D can also be used now
