### PR TITLE
Support for functions added to prototype

### DIFF
--- a/main.js
+++ b/main.js
@@ -140,6 +140,17 @@ define(function (require, exports, module) {
                 params: results.slice(2),
                 prefix: getPrefix(txtFrom, results[0])
             };
+        } else if(txtFrom.indexOf('.prototype.')){
+            var i = 1;
+            for(;i<results.length; i+=1){
+                if(results[i] === 'function'){
+                    return {
+                        name: results[i-1],
+                        params: results.slice(i+1),
+                        prefix: getPrefix(txtFrom, results[0])
+                    };
+                }
+            }
         } else {
             return null;
         }


### PR DESCRIPTION
Hi

I have been using the annotate plugin for a while but really needed to add comments to functions added to the prototype such as:

aFunction.prototype.extraFunction = function (param1, param2){
}

This is the code I have been using to achieve this.
Cheers,
Rob
