### PR TITLE
Added newline characters before prefixes and at end 

### DIFF
--- a/main.js
+++ b/main.js
@@ -190,7 +190,7 @@ define(function (require, exports, module) {
         //output += " * @return {type} ???\n";
         output.push(" */");
 
-        return prefix + output.join(prefix);
+        return prefix + output.join("\n" + prefix) + "\n";
     }
 
 


### PR DESCRIPTION
When using this extension in Brackets on my mac, I was getting one line output like this:

```
/** * Description * @param {type} url, Description * @param {type} callback Description */
```

I modified it to put newlines between each line, resulting in output like this:

```
/**
 * Description
 * @param {type} url Description
 * @param {type} callback Description
 */
```

I hope you find this code tweak helpful... and thanks for creating this extension!  
